### PR TITLE
Support analog inputs and digital i/o

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
   roscpp
   std_msgs
+  sensor_msgs
   phidgets_api
 )
 
@@ -66,10 +67,11 @@ find_package(catkin REQUIRED COMPONENTS
 # )
 
 ## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   std_msgs
-# )
+ generate_messages(
+   DEPENDENCIES
+   std_msgs
+   sensor_msgs
+ )
 
 ################################################
 ## Declare ROS dynamic reconfigure parameters ##
@@ -103,7 +105,7 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package(
   INCLUDE_DIRS include
   # LIBRARIES phidgets_port
-  CATKIN_DEPENDS roscpp std_msgs phidgets_api
+  CATKIN_DEPENDS roscpp std_msgs sensor_msgs phidgets_api message_runtime
   DEPENDS system_lib
 )
 

--- a/README.md
+++ b/README.md
@@ -6,5 +6,7 @@ This package provides support for using the Phidgets InterfaceKit.
 
  * `analog_in` (phidgets_interface_kit/AnalogArray)
  * `digital_in` (phidgets_interface_kit/DigitalArray)
+ * `analog_in_change` (phidgets_interface_kit/AnalogChange)
+ * `digital_in_change` (phidgets_interface_kit/DigitalChange)
 
 ## Subscribed Topics

--- a/msg/AnalogArray.msg
+++ b/msg/AnalogArray.msg
@@ -1,1 +1,1 @@
-int[] values
+int32[] values

--- a/msg/AnalogChange.msg
+++ b/msg/AnalogChange.msg
@@ -1,2 +1,3 @@
-int index   # Sensor index
-int value   # New sensor value
+Header header
+int8 index   # Sensor index
+int8 value   # New sensor value

--- a/msg/DigitalChange.msg
+++ b/msg/DigitalChange.msg
@@ -1,2 +1,3 @@
-int index   # Sensors index
+Header header
+int8 index   # Sensors index
 bool value  # New sensor value

--- a/package.xml
+++ b/package.xml
@@ -11,9 +11,13 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>sensor_msgs</build_depend>
   <build_depend>phidgets_api</build_depend>
+  <build_depend>message_generation</build_depend>
+  <run_depend>message_runtime</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
+  <run_depend>sensor_msgs</run_depend>
   <run_depend>phidgets_api</run_depend>
 
 </package>


### PR DESCRIPTION
This checkin adds full IO support and introduces four topics. Each published topic only queries and transmits values if at least one subscriber is connected.

# ~/analog_in

Analog sensor values as an `phidgets_interface_kit/AnalogArray`

# ~/digital_in

Digital sensor values as a `phidgets_interface_kit/DigitalArray`

# ~/digital_out

Digital outputs as a `phidgets_interface_kit/DigitalArray`

# ~/cmd_digital_out

Requested digital output values as a `phidgets_interface_kit/DigitalArray`

@Kazaroni 